### PR TITLE
Change image URLs to use imports

### DIFF
--- a/client/src/Carousel/LanguageCarousel.js
+++ b/client/src/Carousel/LanguageCarousel.js
@@ -1,6 +1,12 @@
 import React from "react";
 import Carousel from "react-bootstrap/Carousel";
 import "./LanguageCarousel.scss";
+import htmlImage from "./picture/1.png"
+import cssImage from "./picture/2.png"
+import jsImage from "./picture/3.png"
+import reactImage from "./picture/react.png"
+import nodeImage from "./picture/node.png"
+import sqlImage from "./picture/sql.png"
 
 function LanguageCarousel () {
 
@@ -9,7 +15,7 @@ function LanguageCarousel () {
 			<Carousel.Item interval={1000} >
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/1.png"
+					src={htmlImage}
 					alt="First slide"
 				/>
 
@@ -17,7 +23,7 @@ function LanguageCarousel () {
 			<Carousel.Item interval={500}>
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/2.png"
+					src={cssImage}
 					alt="Third slide"
 				/>
 
@@ -25,7 +31,7 @@ function LanguageCarousel () {
 			<Carousel.Item>
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/3.png"
+					src={jsImage}
 					alt="Third slide"
 				/>
 
@@ -33,7 +39,7 @@ function LanguageCarousel () {
 			<Carousel.Item>
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/react.png"
+					src={reactImage}
 					alt="Third slide"
 				/>
 
@@ -41,7 +47,7 @@ function LanguageCarousel () {
 			<Carousel.Item>
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/node.png"
+					src={nodeImage}
 					alt="Third slide"
 				/>
 
@@ -49,7 +55,7 @@ function LanguageCarousel () {
 			<Carousel.Item>
 				<img
 					className="gallery-cell"
-					src="/client/src/Carousel/picture/sql.png"
+					src={sqlImage}
 					alt="Third slide"
 				/>
 


### PR DESCRIPTION
This is so that images will be bundled by webpack
on build

Thank you for contributing! To help the review process, please provide the following:

### Proposal
Importing images means they will be bundled by Webpack when the app is pushed to Heroku. I've made this change as Webpack wasn't part of the syllabus and this was a blocker. @DenizAri - a further suggestion would be to ensure that you are naming the image files consistently.

